### PR TITLE
Changed ECI's table path prefix

### DIFF
--- a/fsw/src/eci_app_cfg.h
+++ b/fsw/src/eci_app_cfg.h
@@ -17,9 +17,9 @@
  * @{
  */
 /** Path to FSW parameter tables */
-#define PARAM_TBL_PATH_PREFIX "/cf/tables/"
+#define PARAM_TBL_PATH_PREFIX "/cf/"
 /** Path to FSW state tables */
-#define STATE_TBL_PATH_PREFIX "/cf/tables/"
+#define STATE_TBL_PATH_PREFIX "/cf/"
 /**@}*/
 
 /**


### PR DESCRIPTION
Changed the ECI path prefix to match the changes made to the cmake build system in cFE 6.6. Close #7 