### PR TITLE
Reorganize includes in eci_app.c to simplify includes for users

### DIFF
--- a/examples/simpleECIApp/fsw/eci_inc/eci_interface.h
+++ b/examples/simpleECIApp/fsw/eci_inc/eci_interface.h
@@ -9,7 +9,6 @@
 /* Include ECI/System headers */
 #include "cfe_evs.h"     /** For access to event type/filter macros in defining events */
 #include "eci_app.h"     /** For access to ECI data types */
-#include "eci_app_cfg.h" /** For access to config parameters (including queue sizes)*/
 
 /** Include all external code to be integrated */
 #include "external_code.h"     /** Include top-level header for external code */

--- a/fsw/src/eci_app.c
+++ b/fsw/src/eci_app.c
@@ -15,18 +15,20 @@
 #include <string.h>
 #include <math.h>
 
-/* External-code interface definition */
-#include "eci_interface.h"
-/* Note: this must be included before the rest of the ECI headers
- * because some of the settings in here affect what's defined by 
- * the headers 
- */
-
-/* ECI headers */
-#include "eci_util_macro.h"
+/* Config-independent ECI headers */
 #include "eci_app_cfg.h"
 #include "eci_app.h"
+#include "eci_util_macro.h"
 #include "eci_app_event.h"
+
+/* External-code interface definition */
+#include "eci_interface.h"
+
+/* Config-dependent ECI headers */
+/* The headers included here must be included after eci_interface.h
+ * which contains configuration macros which affect the definitions 
+ * in the following header files.
+ */
 #include "eci_app_msgdefs.h"
 #include "eci_app_hk.h"
 

--- a/fsw/src/eci_app.h
+++ b/fsw/src/eci_app.h
@@ -13,6 +13,7 @@ extern "C"
 
 
 #include "cfe.h"
+#include "eci_app_cfg.h" /* Needed for queue length macros used by eci_interface.h */
 
 /**@defgroup eci_interface ECI Interface
  * This section contains information on how to properly construct


### PR DESCRIPTION
* Reorganize includes which do not depend on `eci_interface.h` earlier so that values are available are defined for `eci_interface.h`
* Added include of `eci_app_cfg.h` to `eci_app.h` so that users only need include `eci_app.h`
* Clarified comments about include order

Closes #45 