### PR TITLE
Changed the behavior of non-ECI_CMD_MID messages

### DIFF
--- a/fsw/src/eci_app.c
+++ b/fsw/src/eci_app.c
@@ -1565,9 +1565,7 @@ static void app_pipe(const CFE_SB_MsgPtr_t msg) {
          break;
 
       default:
-         CFE_EVS_SendEvent(ECI_INV_MID_ERR_EID, CFE_EVS_ERROR, 
-                           "Invalid MID Received on Command Pipe: ID = 0x%X", messageID);
-         ECI_AppData.HkPacket.CmdErrorCounter++;
+         rcv_msg(msg, messageID, ActualLength, CMDPIPE); /* Receive message prior to execution */
          break;
 
    } /* End switch-statement */

--- a/fsw/src/eci_app_event.h
+++ b/fsw/src/eci_app_event.h
@@ -231,14 +231,6 @@
 #define ECI_INV_CMD_CODE_ERR_EID          168
 
 /**
- * Description:  Application received a message on command pipe with an unrecognized MID<br>
- * Text: "Invalid MID Received on Command Pipe: ID = 0x%X", messageID<br>
- * Type: Error<br>
- * Cause: Application received a message on command pipe with an unrecognized MID<br>
- */
-#define ECI_INV_MID_ERR_EID               169
-
-/**
  * Description:  Application had an error reading the command pipe<br>
  * Text: "SB Command Pipe Read Error, ECI App will Exit."<br>
  * Type: Error<br>

--- a/unit_test/sa_app_test.c
+++ b/unit_test/sa_app_test.c
@@ -84,8 +84,6 @@ void SA_AppMain_Test_ECI_1001_1050(void) {
    /* Verifies that Error Event message sent and command accepted/error counters updated */
    UtAssert_True(HkPacket->CmdErrorCounter == 1, "Command Rejected Counter Incremented");
    UtAssert_True(HkPacket->CmdAcceptCounter == 0, "Command Accepted Counter NOT Incremented");
-   UtAssert_True(Ut_CFE_EVS_GetEventCount(ECI_INV_MID_ERR_EID, CFE_EVS_ERROR, "Invalid MID Received on Command Pipe: ID = 0x1807") == 1, "Error Event Message Outputted");
-
 } /* End of SA_AppMain_Test_ECI_1001_1050 */
 
 /*


### PR DESCRIPTION
This change aims to remove the failure condition on messages
with a value command message id (0x1xxx). The limitations
that ECI was putting on messages registered with the MsgRcv
array doesn't allow for multiple commands and this change will
add the ability to create any number of commands with their
appropriate command structure.

The previous implmenation of the ECI commanding basically did
one check to see wether or not the command had a function
code between ECI_FUNC_CODE_START and ECI_FUNC_CODE_END but
then passed the message into the receive message function.
By directly passing the message with a command function code
into the rcv_msg function, the only check we lose is if that
command has a function code within the range. All other checks
for length and queue buffer size are still tested within this
function.

This commit also removes the test that enforces that expects an
error to be sent when receiving a command message that isn't
ECI_CMD_MID.